### PR TITLE
Add more illustrations, logo links to home page, and update packages

### DIFF
--- a/ui/src/assets/gallery.json
+++ b/ui/src/assets/gallery.json
@@ -1,7 +1,25 @@
 [
   {
     "priority": 1,
+    "id": "1JPWH683Gnsn3VMjLXaWsexmDmZTeTjIg"
+  },
+  {
+    "id": "1MvAlrhWtPmfgGtogh26SJkFRnc5Gh4rD"
+  },
+  {
     "id": "1ZLH7TxcSsFNgsryVQe6kWsFjfeazE05g"
+  },
+  {
+    "id": "1C8d9K1Jbt87qWwUE3hlZrXJxWv5PqW5K"
+  },
+  {
+    "id": "10s9-6MT6EXrmIQIJitkv3RyOi19_r5rH"
+  },
+  {
+    "id": "1Sj3VrzdItaoJaTKUvHs8h5IVft_b-RvO"
+  },
+  {
+    "id": "1-Glmeyv6eRMrmkf6eXe_kzQw4EEyHv0H"
   },
   {
     "id": "1APux_qP3BNWBfOvZuF-Xq9YXC5uks4W1"
@@ -13,7 +31,7 @@
     "id": "1Z4XjZRI-N9G9hfTHjxyLvZbtMA0gJUzH"
   },
   {
-    "id":"1Mx9e7j0W9sxEottavIYXooeaTdZIguuY"
+    "id": "114izo6F7CUg47MLuhuBikKa6i6lDg0EL"
   },
   {
     "id":"1R9u-oIJWTJGXRK0pcjKttB_ZK9frlAfr"

--- a/ui/src/components/NavBar.vue
+++ b/ui/src/components/NavBar.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1>Elipri</h1>
+    <router-link to='/'>
+      <h1>Elipri</h1>
+    </router-link>
     <ul>
       <li>
         <router-link to='/animations'>Animations</router-link>


### PR DESCRIPTION
Resolves: #13 

new changes:
- Add more illustrations to illustration page.
- Logo at the top now links to home page when linked, regardless of what page user is on.
- update all packages (except typescript) to latest version and fix `javascript-serialize` security issue (although it was not really a threat for us).
- remove googleapis as a dependency because, for now, it is not needed.